### PR TITLE
Change chat appearance

### DIFF
--- a/src/actions/chatActions.js
+++ b/src/actions/chatActions.js
@@ -35,7 +35,10 @@ export const getConversations = createThunk(GET_CONVERSATIONS, async () => {
 // get all messages from a conversation (1 conversation = * messages)
 export const getMessages = createThunk(GET_MESSAGES, async (id, page) => {
   try {
-    return (await chatService.getMessages(id, page)).data.messages;
+    const {
+      data: { messages },
+    } = await chatService.getMessages(id, page);
+    return { messages, page };
   } catch ({ data }) {
     throw parseError(data);
   }

--- a/src/components/chat/Bubble/index.js
+++ b/src/components/chat/Bubble/index.js
@@ -1,0 +1,23 @@
+import React from 'react';
+import { Bubble as BubbleRN } from 'react-native-gifted-chat';
+
+import styles from './styles';
+
+const Bubble = ({ bubbleProps }) => (
+  <BubbleRN
+    {...bubbleProps}
+    wrapperStyle={{
+      right: styles.wrapperRight,
+    }}
+    textStyle={{
+      left: styles.textBlack,
+      right: styles.textBlack,
+    }}
+    timeTextStyle={{
+      left: styles.textBlack,
+      right: styles.textBlack,
+    }}
+  />
+);
+
+export default Bubble;

--- a/src/components/chat/Bubble/styles.js
+++ b/src/components/chat/Bubble/styles.js
@@ -1,0 +1,15 @@
+import { StyleSheet } from 'react-native';
+
+import { BLACK, YELLOW } from 'constants/colors';
+
+const styles = StyleSheet.create({
+  textBlack: {
+    color: BLACK,
+  },
+
+  wrapperRight: {
+    backgroundColor: YELLOW,
+  },
+});
+
+export default styles;

--- a/src/components/chat/Send/index.js
+++ b/src/components/chat/Send/index.js
@@ -1,0 +1,15 @@
+import React from 'react';
+import { Text } from 'react-native';
+import { Send as SendRN } from 'react-native-gifted-chat';
+
+import strings from 'locale';
+import styles from './styles';
+
+const { CHAT } = strings;
+const Send = ({ sendProps }) => (
+  <SendRN {...sendProps}>
+    <Text style={styles.sendText}>{CHAT.send}</Text>
+  </SendRN>
+);
+
+export default Send;

--- a/src/components/chat/Send/styles.js
+++ b/src/components/chat/Send/styles.js
@@ -1,0 +1,15 @@
+import { StyleSheet } from 'react-native';
+
+import { YELLOW } from 'constants/colors';
+
+const styles = StyleSheet.create({
+  sendText: {
+    color: YELLOW,
+    fontSize: 20,
+    fontWeight: 'bold',
+    marginBottom: 10,
+    marginRight: 10,
+  },
+});
+
+export default styles;

--- a/src/constants/chat.js
+++ b/src/constants/chat.js
@@ -1,2 +1,3 @@
 export const CHAT_CHANNEL = 'ChatChannel';
+export const CHAT_PAGE_COUNT = 10;
 export const SEND_MESSAGE = 'send_message';

--- a/src/locale/en.js
+++ b/src/locale/en.js
@@ -5,6 +5,7 @@ export default {
   },
 
   CHAT: {
+    send: 'Send',
     start: 'Start a conversation with ',
   },
 

--- a/src/locale/es.js
+++ b/src/locale/es.js
@@ -5,6 +5,7 @@ export default {
   },
 
   CHAT: {
+    send: 'Enviar',
     start: 'Empieza una conversación con ',
   },
 

--- a/src/reducers/chatReducer.js
+++ b/src/reducers/chatReducer.js
@@ -8,6 +8,10 @@ import {
 
 const initialState = { matches: [] };
 
+const isInCollection = (array, id) => {
+  return array.find(({ id: elementId }) => elementId === id);
+};
+
 const chatReducer = {
   [CLEAR_CHAT_STATE]: store => {
     store.messages = undefined;
@@ -17,8 +21,15 @@ const chatReducer = {
     store.matches = payload;
   },
 
-  [getMessagesSuccess]: (store, { payload }) => {
-    store.messages = payload;
+  [getMessagesSuccess]: (store, { payload: { messages, page } }) => {
+    if (page !== 1) {
+      const newMessages = messages.filter(({ id }) => {
+        return !isInCollection(store.messages, id);
+      });
+      store.messages = [...newMessages, ...store.messages];
+    } else {
+      store.messages = messages;
+    }
   },
 
   [RECEIVE_MESSAGE]: (store, { payload }) => {

--- a/src/screens/ChatScreen/index.js
+++ b/src/screens/ChatScreen/index.js
@@ -12,6 +12,7 @@ import {
   subscribe,
   unsubscribe,
 } from 'actions/chatActions';
+import defaultProfileImage from 'assets/images/default_profile_image.png';
 import { CHAT_PAGE_COUNT } from 'constants/chat';
 import { targetMatchParam } from 'constants/parameters';
 import Send from 'components/chat/Send';
@@ -62,7 +63,10 @@ const ChatScreen = () => {
             _id: id,
             text: content,
             createdAt: date,
-            user: { _id: messageUserId, avatar: url },
+            user: {
+              _id: messageUserId,
+              avatar: url ? url : defaultProfileImage,
+            },
           };
         })
         .reverse());

--- a/src/screens/ChatScreen/index.js
+++ b/src/screens/ChatScreen/index.js
@@ -21,6 +21,7 @@ const ChatScreen = () => {
   const dispatch = useDispatch();
 
   const info = useSelector(({ session: { info } }) => info);
+  const userId = useSelector(({ session: { userId } }) => userId);
 
   useEffect(() => {
     const dispatches = async () => {
@@ -42,15 +43,29 @@ const ChatScreen = () => {
 
   let messages = useMemo(() => {
     if (messagesSession) {
-      return (messages = messagesSession.map(message => {
-        const { id } = message;
-        return {
-          ...message,
-          _id: id,
-        };
-      }));
+      return (messages = messagesSession
+        .map(message => {
+          const {
+            id,
+            content,
+            date,
+            user: {
+              id: messageUserId,
+              avatar: { url },
+            },
+          } = message;
+          return {
+            _id: id,
+            text: content,
+            createdAt: date,
+            user: { _id: messageUserId, avatar: url },
+          };
+        })
+        .reverse());
     }
   }, [messagesSession]);
+
+  console.log('messages: ', messages);
 
   const handleOnSend = newMessages => {
     const [message] = newMessages;
@@ -60,16 +75,15 @@ const ChatScreen = () => {
   return (
     <>
       <GiftedChat
+        alignTop
+        alwaysShowSend
+        bottomOffset={0}
         messages={messages}
         onSend={handleOnSend}
-        renderAvatar={null}
-        alwaysShowSend
-        renderMessage={({ currentMessage: { content } }) => (
-          <Text>{content}</Text>
-        )}
-        invertibleScrollViewProps={{ overScrollMode: 'never' }}
-        alignTop
-        bottomOffset={0}
+        showUserAvatar
+        user={{
+          _id: userId,
+        }}
       />
     </>
   );

--- a/src/screens/ProfileScreen/index.js
+++ b/src/screens/ProfileScreen/index.js
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect } from 'react';
-import { ImageBackground, TouchableOpacity } from 'react-native';
+import { ImageBackground, ScrollView, TouchableOpacity } from 'react-native';
 import { useDispatch, useSelector } from 'react-redux';
 import { useStatus, ERROR, LOADING, SUCCESS } from '@rootstrap/redux-tools';
 
@@ -107,7 +107,7 @@ const ProfileScreen = ({ navigation }) => {
   });
 
   return (
-    <>
+    <ScrollView showsVerticalScrollIndicator={false}>
       <ImageBackground
         resizeMode="contain"
         source={profileLogo}
@@ -162,7 +162,7 @@ const ProfileScreen = ({ navigation }) => {
         onPress={handleLogout}
         text={logoutStatus === LOADING ? COMMON.loading : PROFILE.logOut}
       />
-    </>
+    </ScrollView>
   );
 };
 


### PR DESCRIPTION
This PR is to improve chat's appearance since the last PR was only functional but not nice to the eye. 

It also adds the option to get older chats by pressing the `load earlier messages` button (it fetches 10 each time since that is how backend returns pages with 10 elements).

There was a complication about adding new messages (now I have more than 10) and then fetching older messages. To handle this I do 2 things:

1. I don't keep track of the last page I got, I calculate which one I have to get now with this formula: `Math.floor(messages.length / CHAT_PAGE_COUNT) + 1` having a configuration `CHAT_PAGE_COUNT=10`. If backend changes this configuration has to change too.

2.  When I do step one, I could have repeated messages, for example: 
-  I had 10 messages
- then I send or receive 2 new messages so I have 12
- when I fetch older messages I have to get page 2, but the last 2 messages would be the same as the first 2 I already have now (that difference between 12 and 10, now the first 2 are part of the next page, in this case, page 2).
To address this I have to check, when I fetch a page different than page 1, if it's already in the collection don't add it again.

I leave an example where I add texts in numerical and alphabetical order so it's easy to check there is no message repeated or missing.

![](http://g.recordit.co/XXApo38xH4.gif)


EDIT:  I saw in the gif that one user's avatar wasn't showing because is empty, now in these cases, I set default avatar: 

![image](https://user-images.githubusercontent.com/8755889/76762804-be01ab80-6770-11ea-8708-6ebc05bab32f.png)
